### PR TITLE
Add label to match service.yml selector

### DIFF
--- a/structural/Adapter/pod.yml
+++ b/structural/Adapter/pod.yml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: random-generator
+  labels:
+    app: random-generator
 spec:
   containers:
   # ------------------------------------------------


### PR DESCRIPTION
I was reviewing the structural examples and the Adapter services where not working because the label was missing