### PR TITLE
feat: update the k8s autoscaler api and vap install process

### DIFF
--- a/advanced/ElasticScale/README.adoc
+++ b/advanced/ElasticScale/README.adoc
@@ -39,6 +39,11 @@ kubectl delete hpa random-generator
 # Check that HPA is deleted
 
 # Install VPA according to https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler
+'''
+git clone git@github.com:kubernetes/autoscaler.git
+cd ./autoscaler/vertical-pod-autoscaler
+./hack/vpa-up.sh
+'''
 
 # Deploy app if not already deployed
 kubectl create -f deployment.yml

--- a/advanced/ElasticScale/hpa.yml
+++ b/advanced/ElasticScale/hpa.yml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: random-generator


### PR DESCRIPTION
Hello ! I have updated some features with the Chapter 24 elastic scale.

This pull request includes the following changes:

1. Update the content of the .yml file in chapter 24: elastic scale HPA example. Modify the `apiVersion` from `autoscaling/v2beta2` to `autoscaling/v2`.

2. Add the VAP install process to the README file.
```
git clone git@github.com:kubernetes/autoscaler.git
cd ./autoscaler/vertical-pod-autoscaler
./hack/vpa-up.sh
```

These changes aim to improve compatibility and provide clearer instructions for the Kubernetes autoscaler API and VAP installation.

Please review and merge this pull request at your earliest convenience.

Thank you!
