### PR TITLE
Actions and link checker updates

### DIFF
--- a/.github/check_links.py
+++ b/.github/check_links.py
@@ -19,7 +19,7 @@ def check_links(links, index_yml_path):
                 error_occurred = True
         except requests.exceptions.RequestException as e:
             print(f"{directory}: Checking {url} ... ERROR")
-            errors.append((index_yml_path, url, str(e)))
+            errors.append((index_yml_path, url, link['title'], str(e)))
             error_occurred = True
 
 def process_directory(root, filenames):

--- a/.github/check_links.py
+++ b/.github/check_links.py
@@ -19,7 +19,7 @@ def check_links(links, index_yml_path):
     for link in links:
         url = link['url']
         try:
-            response = session.get(url, headers=headers, allow_redirects=True, timeout=10)
+            response = session.head(url, headers=headers, allow_redirects=True, timeout=10)
             print(f"{directory}: Checking {url} ... {response.status_code}")
             if response.status_code != 200:
                 errors.append((index_yml_path, url, link['title'], response.status_code))

--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Python 3.9
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
 


### PR DESCRIPTION
The current actions are failing due to outdated GitHub Actions setup.

See issues at e.g. https://github.com/k8spatterns/examples/actions/runs/8104918636
    
    Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v3.
    For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

The link checker also had some transient errors, and took more time than it was necessary.

- transient errors are reduced by using retries in the requests
- added custom `User-Agent` to avoid some spurious 403 errors due to the default user agent used by requests
- switched to using Sessions and HEAD, rather than GET requests for shaving off ~30% time to check links
- fixed a bug when request exceptions resulted in missing output in the end